### PR TITLE
Made the console.log() regex lazy

### DIFF
--- a/tasks/grunt-remove-logging.js
+++ b/tasks/grunt-remove-logging.js
@@ -9,7 +9,7 @@
 module.exports = function(grunt) {
   "use strict";
 
-  var rConsole = /console.(?:log|warn|error|assert|count|clear|group|groupEnd|trace|debug|dir|dirxml|profile|profileEnd|time|timeEnd)\([^;]*\);?/gi;
+  var rConsole = /console.(?:log|warn|error|assert|count|clear|group|groupEnd|trace|debug|dir|dirxml|profile|profileEnd|time|timeEnd)\([^;]*?\);?/gi;
 
   grunt.registerMultiTask("removelogging", "Remove console logging", function() {
     var src = grunt.task.directive(this.file.src, grunt.file.read);


### PR DESCRIPTION
Before this, it would delete not only the console.log() line, but the next lines also if there was not a semicolon at the end.
