### PR TITLE
Allow users to specify only a 'src' option and have it overwrite the file.

### DIFF
--- a/tasks/grunt-remove-logging.js
+++ b/tasks/grunt-remove-logging.js
@@ -15,18 +15,26 @@ module.exports = function(grunt) {
     var opts = this.options();
 
     this.files.forEach(function(f) {
-      var ret = f.src.map(function(srcFile) {
-        if (grunt.file.isFile(srcFile)){
+      if (typeof f.dest === "undefined") {
+        f.src.forEach(function (srcFile) {
           var result = task(grunt.file.read(srcFile), opts);
-          grunt.log.writeln("Removed " + result.count + " logging statements from " + srcFile);
-          return result.src;
-        }else{
-          grunt.log.error("File not found " + srcFile);
-        }
-      }).join("");
+          grunt.log.writeln("Removed " + result.count + " logging statements from " + srcFile + ". (File Overwritten)");
+          grunt.file.write(srcFile, ret);
+        });
+      } else {
+        var ret = f.src.map(function(srcFile) {
+          if (grunt.file.isFile(srcFile)){
+            var result = task(grunt.file.read(srcFile), opts);
+            grunt.log.writeln("Removed " + result.count + " logging statements from " + srcFile);
+            return result.src;
+          }else{
+            grunt.log.error("File not found " + srcFile);
+          }
+        }).join("");
 
-      if(ret){
-        grunt.file.write(f.dest, ret);
+        if(ret){
+          grunt.file.write(f.dest, ret);
+        }
       }
     });
   });

--- a/tasks/grunt-remove-logging.js
+++ b/tasks/grunt-remove-logging.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
         f.src.forEach(function (srcFile) {
           var result = task(grunt.file.read(srcFile), opts);
           grunt.log.writeln("Removed " + result.count + " logging statements from " + srcFile + ". (File Overwritten)");
-          grunt.file.write(srcFile, ret);
+          grunt.file.write(srcFile, result.src);
         });
       } else {
         var ret = f.src.map(function(srcFile) {


### PR DESCRIPTION
I actually submitted a pull-request to Grunt to allow this functionality out of the box - not accepted unfortunately. :(

Anyway, this PR will allow for users to only specify a SRC option and then it will overwrite each file that is matched.

``` javascript
removelogging: {
      dist: {
        src: ["app/js/test/*.js"] /* all matching files will be overwritten */
      }
}
```
