### PR TITLE
Modified RE to support multiple namespaces

### DIFF
--- a/tasks/lib/removelogging.js
+++ b/tasks/lib/removelogging.js
@@ -17,7 +17,7 @@ exports.init = function(grunt) {
       opts.methods = "log warn error assert count clear group groupEnd groupCollapsed trace debug dir dirxml profile profileEnd time timeEnd timeStamp table exception".split(" ");
     }
 
-    rConsole = new RegExp(opts.namespace + ".(?:" + opts.methods.join("|") + ")\\s{0,}\\([^;]*\\)(?!\\s*[;,]?\\s*\\/\\*\\s*RemoveLogging:skip\\s*\\*\\/);?", "gi");
+    rConsole = new RegExp("(" + opts.namespace.join("|") + ")" + ".(?:" + opts.methods.join("|") + ")\\s{0,}\\([^;]*\\)(?!\\s*[;,]?\\s*\\/\\*\\s*RemoveLogging:skip\\s*\\*\\/);?", "gi");
 
     src = src.replace(rConsole, function() {
       counter++;

--- a/test/test.js
+++ b/test/test.js
@@ -99,8 +99,8 @@ var tests = [
   // namespace option tests
 
   [
-    'logger.log("foo")',
-    { namespace: 'logger' },
+    'logger.log("foo");that.log("foo");this.log("foo")',
+    { namespace: ['logger','that.log','this.log'] },
     '',
   ],
 

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -10,3 +10,7 @@ console.warn([foo]);
 console.log("(foo)");
 foo1 console.log(foo); foo2
 foo1 console.log(foo);foo2;
+
+foo1 this.log(foo);bar;
+foo2;that.log(bar);foo;
+


### PR DESCRIPTION
Sometimes we need multiple namespaces like `['that.log','this.log','console','log','self']`
