### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ grunt.initConfig({
 ```
 
 To run this task against multiple files and **automatically overwrite them**
-with the resultant output, omit the `dist` option:
+with the resultant output, omit the `dest` option:
 
 ```js
 grunt.initConfig({


### PR DESCRIPTION
changed 'omit the `dist` option' to  the `dest` option as shown in the example
