### PR TITLE
added an option to comment the code, i.e. --type comment

### DIFF
--- a/tasks/grunt-remove-logging.js
+++ b/tasks/grunt-remove-logging.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
 
     var process = function(srcFile) {
       var result = task(grunt.file.read(srcFile), opts);
-      grunt.log.writeln("Removed " + result.count + " logging statements from " + srcFile);
+      var type = grunt.option('type') === "comment" ? "Commented " : "Removed ";
+      grunt.log.writeln(type + result.count + " logging statements from " + srcFile);
       return result;
     };
 

--- a/tasks/lib/removelogging.js
+++ b/tasks/lib/removelogging.js
@@ -20,10 +20,20 @@ exports.init = function(grunt) {
     rConsole = new RegExp("(" + opts.namespace.join("|") + ")" + ".(?:" + opts.methods.join("|") + ")\\s{0,}\\([^;]*\\)(?!\\s*[;,]?\\s*\\/\\*\\s*RemoveLogging:skip\\s*\\*\\/)\\s{0,};?", "gi");
 
     src = src.replace(rConsole, function() {
-      counter++;
-      return opts.replaceWith || "";
+      var type = grunt.option('type') || "comment";
+      var matches = src.match(rConsole);
+      if(type === 'comment'){
+        var commented = [];
+        counter++;
+        for(var i = 0; i < matches.length; i++){
+          commented[i] = "//" + matches[i];
+          return commented[i];
+        }       
+      }else {
+        counter++;
+        return opts.replaceWith || "";
+      }
     });
-
     return {
       src: src,
       count: counter


### PR DESCRIPTION
I needed to just comment the code and not delete it, so I did a small modification and added an option to the task,typing --type comment will comment out all the code.
I did this because then the commented code is removed when minified in production.
I don't know if it's a feature that you'd like to have on the plugin, but I needed it so I added and I thought you might want to look at it :)
