### PR TITLE
Bug fix for "code destruction due missing semicolon in commented lines"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,14 +3,14 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     nodeunit: {
-      all: ["test/**/*.js"]
+      all: ["test/**/*.js", "!test/samples/*"]
     },
     watch: {
       files: "<config:lint.files>",
       tasks: "default"
     },
     jshint: {
-      all: ["grunt.js", "tasks/**/*.js", "test/**/*.js"],
+      all: ["grunt.js", "tasks/**/*.js", "test/**/*.js", "!test/samples/*"],
       options: {
         curly: true,
         eqeqeq: true,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Defaults to `[ 'console', 'window.console' ]`. If you use a custom logger, like
 `MyApp.logger.log(foo)`, you would set this option to `[MyApp.logger]`.
 * `methods`: An array of method names to remove. Defaults to [all the methods](http://getfirebug.com/wiki/index.php/Console_API) in the Firebug console API. This option is useful if you want to strip out all `log` methods, but keep `warn` for example.
 * `verbose`: Boolean value, whether to show count of logging statements removed for each file. Defaults to true. If false, a single summary line is logged to grunt instead.
+* `forceProperLineEnd`: Boolean value, defaults to `false`. Set to true and it will add a semi-colon to the end of the line, if it is missing. This stops some cases from causing malformed JS. If you leave it as `false`, you will simply get a console warning, telling you where the missing semi-colon is located.
 
 ### Skipping Individual Statements
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "grunt-remove-logging",
   "description" : "Grunt task to remove console logging statements",
-  "version" : "0.2.1",
+  "version" : "0.2.2",
   "homepage" : "",
   "author" : {
     "name" : "Eric Hynds",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "grunt-remove-logging",
   "description" : "Grunt task to remove console logging statements",
-  "version" : "0.2.2",
+  "version" : "0.2.1",
   "homepage" : "",
   "author" : {
     "name" : "Eric Hynds",

--- a/tasks/grunt-remove-logging.js
+++ b/tasks/grunt-remove-logging.js
@@ -17,8 +17,7 @@ module.exports = function(grunt) {
     var statementCount = 0, fileCount = 0;
 
     var process = function(srcFile) {
-      opts.srcFile = srcFile;
-      var result = task(grunt.file.read(srcFile), opts);
+      var result = task(grunt.file.read(srcFile), opts, srcFile);
       statementCount += result.count;
       fileCount++;
       if (opts.verbose) {

--- a/tasks/grunt-remove-logging.js
+++ b/tasks/grunt-remove-logging.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
     var statementCount = 0, fileCount = 0;
 
     var process = function(srcFile) {
+      opts.srcFile = srcFile;
       var result = task(grunt.file.read(srcFile), opts);
       statementCount += result.count;
       fileCount++;

--- a/tasks/lib/removelogging.js
+++ b/tasks/lib/removelogging.js
@@ -3,7 +3,7 @@ exports.init = function(grunt) {
 
   var _ = grunt.util._;
 
-  return function(src, opts) {
+  return function(src, opts, origin) {
     var counter = 0;
     var rConsole;
 
@@ -26,12 +26,13 @@ exports.init = function(grunt) {
      * they don't, with a message pointing to the location of the problem. 
      * By default it doesn't fix the problem for you, just points you in the direction of the problem so you can fix your code.
      * If option 'forceProperLineEnd' is set to true though, it will add the semi-colon to the end of the line.
+     * Addresses issue 18: https://github.com/ehynds/grunt-remove-logging/issues/18
      */
     if( _.isArray(opts.methods) ) {
       opts.methods.forEach(function(meth) {
 
-        var splitter = "console."+meth
-            ,newSrc = "";
+        var splitter = "console."+meth,
+            newSrc = "";
         src.split( splitter ).forEach(function(str, i) {
 
           newSrc += (i>0 ? splitter : "");
@@ -39,8 +40,8 @@ exports.init = function(grunt) {
           var modStr = null;
 
           if( i>0 && str.indexOf("\n") !== -1 ) {
-            var thisLine = str.split("\n")[0].trim()
-                ,lastChar = thisLine[ thisLine.length-1 ];
+            var thisLine = str.split("\n")[0].trim(),
+              lastChar = thisLine[ thisLine.length-1 ];
 
             if( thisLine.indexOf("RemoveLogging:skip") === -1 && lastChar !== ";" ) {
               if( opts.forceProperLineEnd ) {
@@ -49,12 +50,12 @@ exports.init = function(grunt) {
                 
                 grunt.log.warn( "WARNING: Added semi-colon to line ".yellow +
                   "\nconsole.".cyan + meth.cyan + thisLine.cyan +
-                  "\nIn file ".yellow + opts.srcFile.yellow + 
+                  "\nIn file ".yellow + origin.yellow + 
                   "\n\n" );
               } else {
                 grunt.log.warn( "WARNING: line with console statement does not finish with ';'. ".red+
                   "This will likely cause unexpected results in 'grunt-remove-logging'.".red+
-                  "\nIn file ".yellow + opts.srcFile.yellow + ", search for the following string to debug it: ".yellow + 
+                  "\nIn file ".yellow + origin.yellow + ", search for the following string to debug it: ".yellow + 
                   "\nconsole.".cyan + meth.cyan + thisLine.cyan+
                   "\n\n" );
               }
@@ -65,7 +66,9 @@ exports.init = function(grunt) {
           
         });
 
-        if( newSrc != "" ) src = newSrc;
+        if( newSrc !== "" ) {
+          src = newSrc;
+        }
       
       });
     }

--- a/tasks/lib/removelogging.js
+++ b/tasks/lib/removelogging.js
@@ -43,7 +43,7 @@ exports.init = function(grunt) {
             var thisLine = str.split("\n")[0].trim(),
               lastChar = thisLine[ thisLine.length-1 ];
 
-            if( thisLine.indexOf("RemoveLogging:skip") === -1 && lastChar !== ";" ) {
+            if( thisLine.indexOf("RemoveLogging:skip") === -1 && lastChar !== ";" && thisLine.indexOf("function(") === -1 ) {
               if( opts.forceProperLineEnd ) {
 
                 modStr = str.replace( "\n", ";\n" );

--- a/test/samples/sample1-after.js
+++ b/test/samples/sample1-after.js
@@ -1,0 +1,5 @@
+(function() {
+	var a = 2;
+	
+	var b = 8;
+}()

--- a/test/samples/sample1-before.js
+++ b/test/samples/sample1-before.js
@@ -1,0 +1,6 @@
+(function() {
+	var a = 2;
+	
+	console.log( a )
+	var b = 8;
+}()

--- a/test/samples/sample2-after.js
+++ b/test/samples/sample2-after.js
@@ -1,0 +1,6 @@
+(function() {
+	var a = 2;
+
+	//edw
+	var b = 8;
+}()

--- a/test/samples/sample2-before.js
+++ b/test/samples/sample2-before.js
@@ -1,0 +1,6 @@
+(function() {
+	var a = 2;
+
+	console.log( a )//edw
+	var b = 8;
+}()

--- a/test/test.js
+++ b/test/test.js
@@ -205,7 +205,30 @@ var tests = [
     'pre;console.log("foo") ;post;',
     { replaceWith: "" },
     "pre;post;"
+  ],
+
+  // Issue #18 - no ';' at line end breaking code
+  [
+    'var xxxx;console.log()\n',
+    { methods: [ 'log' ], forceProperLineEnd: true },
+    "var xxxx;\n"
+  ],
+  [
+    'var xxxx;console.log();\n',
+    { methods: [ 'log' ] },
+    "var xxxx;\n"
+  ],
+  [
+    'var xxxx;console.warn()\n',
+    { methods: [ 'warn' ], forceProperLineEnd: true },
+    "var xxxx;\n"
+  ],
+  [
+    'var xxxx;console.warn();\n',
+    { methods: [ 'warn' ] },
+    "var xxxx;\n"
   ]
+  // TODO: tests done on Windows 8.1. Need to run on OSX, mainly because of different line break syntax
 ];
 
 exports.tests = {
@@ -216,8 +239,8 @@ exports.tests = {
   remove_logging: function(test) {
     test.expect(tests.length);
 
-    tests.forEach(function(t) {
-      var result = task(t[0], t[1]);
+    tests.forEach(function(t, i) {
+      var result = task(t[0], t[1], "test"+i);
       test.equal(result.src, t[2]);
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -213,6 +213,11 @@ var tests = [
     { methods: [ 'log' ], forceProperLineEnd: true },
     "var xxxx;\n"
   ],
+  [ // if the keyword "function(" is found on the same line, it will ignore it
+    'var xxxx;console.log = function()\n',
+    { methods: [ 'log' ], forceProperLineEnd: true },
+    "var xxxx;console.log = function()\n"
+  ],
   [
     'var xxxx;console.log();\n',
     { methods: [ 'log' ] },

--- a/test/test.js
+++ b/test/test.js
@@ -218,6 +218,17 @@ var tests = [
     { methods: [ 'log' ] },
     "var xxxx;\n"
   ],
+  // testing actual JS files, so that any discrepencies between OSs and line breaks can be captured
+  [
+    grunt.file.read("./test/samples/sample1-before.js"),
+    { methods: [ 'log' ] },
+    grunt.file.read("./test/samples/sample1-after.js")
+  ],
+  [
+    grunt.file.read("./test/samples/sample2-before.js"),
+    { methods: [ 'log' ] },
+    grunt.file.read("./test/samples/sample2-after.js")
+  ],
   [
     'var xxxx;console.warn()\n',
     { methods: [ 'warn' ], forceProperLineEnd: true },
@@ -228,7 +239,6 @@ var tests = [
     { methods: [ 'warn' ] },
     "var xxxx;\n"
   ]
-  // TODO: tests done on Windows 8.1. Need to run on OSX, mainly because of different line break syntax
 ];
 
 exports.tests = {


### PR DESCRIPTION
Faced the same issue that was raised in this ticket:
https://github.com/ehynds/grunt-remove-logging/issues/18

Fix will check all console statement lines to see if they end with a semi-colon and throw warning if they don't, with a message pointing to the location of the problem. 
By default it doesn't fix the problem for you, just points you in the direction of the problem so you can fix your code.
If option 'forceProperLineEnd' is set to true though, it will add the semi-colon to the end of the line before continuing.

I've added tests for this, including some sample js files, so line breaks across OSs can be captured. Just having line breaks in strings wouldn't do this. I've tested OSX Maveriks and Windows 7 and 8.1 and they all pass tests, treating line breaks as the '\n' character. I have been stung by different linebreak characters before though, which is why I'm adding this test. 

Also updated the README.md file with this option.
