### PR TITLE
Fixed issue with logs where message contains semicolon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "grunt-remove-logging",
   "description" : "Grunt task to remove console logging statements",
-  "version" : "0.2.1",
+  "version" : "0.2.2",
   "homepage" : "",
   "author" : {
     "name" : "Eric Hynds",

--- a/tasks/lib/removelogging.js
+++ b/tasks/lib/removelogging.js
@@ -21,7 +21,7 @@ exports.init = function(grunt) {
       opts.verbose = true;
     }
 
-    rConsole = new RegExp("(" + opts.namespace.join("|") + ")" + ".(?:" + opts.methods.join("|") + ")\\s{0,}\\([^;]*\\)(?!\\s*[;,]?\\s*\\/\\*\\s*RemoveLogging:skip\\s*\\*\\/)\\s{0,};?", "gi");
+    rConsole = new RegExp("(" + opts.namespace.join("|") + ")" + ".(?:" + opts.methods.join("|") + ")\\s{0,}\\((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*\\)(?!\\s*[;,]?\\s*\\/\\*\\s*RemoveLogging:skip\\s*\\*\\/)\\s{0,};?", "gi");
 
     src = src.replace(rConsole, function() {
       counter++;

--- a/test/test.js
+++ b/test/test.js
@@ -205,6 +205,18 @@ var tests = [
     'pre;console.log("foo") ;post;',
     { replaceWith: "" },
     "pre;post;"
+  ],
+
+  // Logging with semicolon
+  [
+    'console.log("Ok;");',
+    { replaceWith: "" },
+    ""
+  ],
+  [
+    'console.log(["Test", "Ok"].map(function(s){return s;}));',
+    { replaceWith: "" },
+    ""
   ]
 ];
 


### PR DESCRIPTION
Log messages that contains a semicolon are not replaced correctly. For example:
`console.log("Ok;");`
or
`console.log(["Test", "Ok"].map(function(s){return s;}));`
I've added two unit tests that are failing with the current code. 

This PR updates the Regex inner expression to detect the log message from:
`\([^;]*\)`
to
`\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\)`

The new expression is based on matching nested brackets. Note that this will only work up to two levels of nesting. To add levels, you could change the middle (second) [^()]\* part to ([^()]_|([^()]_))*, but I believe supporting two levels should be sufficient for most cases. 
